### PR TITLE
ansi c do NOT support single line comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS?=-std=gnu99 -ansi -pedantic -O4 -Wall -fPIC
+CFLAGS?=-std=gnu99 -pedantic -O4 -Wall -fPIC
 
 default: websocket_parser.o
 
@@ -7,5 +7,9 @@ websocket_parser.o: websocket_parser.c websocket_parser.h
 solib: websocket_parser.o
 	$(CC) -shared -Wl,-soname,libwebsocket_parser.so -o libwebsocket_parser.so websocket_parser.o
 
+alib: websocket_parser.o
+	ar rcu libwebsocket_parser.a $<
+	ranlib libwebsocket_parser.a
+
 clean:
-	rm -f *.o *.so
+	rm -f *.o *.so *.a


### PR DESCRIPTION
1. ANSI c don't support single line comment.It won't compile.
2. Add static library compile option,in case someone needs it as i do.